### PR TITLE
support for kitty (0.19.3) and terminator (1.9.1)

### DIFF
--- a/src/main/java/com/sburlyaev/cmd/plugin/CommandBuilder.java
+++ b/src/main/java/com/sburlyaev/cmd/plugin/CommandBuilder.java
@@ -83,10 +83,13 @@ public class CommandBuilder {
                     case GNOME_TERMINAL:
                         return new Command(command, "--working-directory", projectDirectory);
                     case KONSOLE:
-                        return new Command(command, "--workdir", projectDirectory);
+                        return new Command(command, "--new-tab", "--workdir", projectDirectory);
+                    case TERMINATOR:
+                        return new Command(command, "--new-tab", "--working-directory", projectDirectory);
+                    case KITTY:
+                        return new Command(command, "-1", "-d", projectDirectory);
                     case RXVT:
                         return new Command(command, "-cd", projectDirectory);
-
                     default:
                         return new Command(command);
                 }

--- a/src/main/java/com/sburlyaev/cmd/plugin/model/Terminal.java
+++ b/src/main/java/com/sburlyaev/cmd/plugin/model/Terminal.java
@@ -17,6 +17,8 @@ public enum Terminal {
     GNOME_TERMINAL("gnome-terminal", "/usr/bin/gnome-terminal"),
     KONSOLE("konsole", "/usr/bin/konsole"),
     RXVT("rxvt"),
+    TERMINATOR("terminator"),
+    KITTY("kitty"),
 
     // macOS
     MAC_TERMINAL("Terminal"),


### PR DESCRIPTION
I've added the support for these two linux terminals.
In terminator the plugin will open, by default, a new tab if an instance is already open.
In kitty it will create a new terminal in single instance mode (-1)